### PR TITLE
Possibility to run appium with custom chromedriver executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Appium is automation test framework to test mobile website and mobile applicatio
 ```bash
 docker run --privileged -d -p 6080:6080 -p 5554:5554 -p 5555:5555 -p 4723:4723 -e DEVICE="Samsung Galaxy S6" -e APPIUM=True --name android-container butomo1989/docker-android-x86-7.1.1
 ```
+It is possible to start appium with custom chromedriver executable by mounting directory with chromedriver inside container and passing an environment variable ***CHROMEDRIVER_EXECUTABLE=path_to_chromedriver***
+```bash
+docker run --privileged -d -p 6080:6080 -p 5554:5554 -p 5555:5555 -p 4723:4723 -v /path/to/chromedriver:/root/chromedriver  -e CHROMEDRIVER_EXECUTABLE=/root/chromedriver/chromedriver -e DEVICE="Samsung Galaxy S6" -e APPIUM=True --name android-container butomo1989/docker-android-x86-7.1.1
+```
 
 ### Connect to Selenium Grid
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Appium is automation test framework to test mobile website and mobile applicatio
 ```bash
 docker run --privileged -d -p 6080:6080 -p 5554:5554 -p 5555:5555 -p 4723:4723 -e DEVICE="Samsung Galaxy S6" -e APPIUM=True --name android-container butomo1989/docker-android-x86-7.1.1
 ```
-It is possible to start appium with custom chromedriver executable by mounting directory with chromedriver inside container and passing an environment variable ***CHROMEDRIVER_EXECUTABLE=path_to_chromedriver***
+It is possible to start appium with custom chromedriver executable by mounting directory with chromedriver inside container and passing an environment variable ***CHROMEDRIVER_EXECUTABLE=path_to_chromedriver***   
+[chromedriver] repo contains all versions of chromedriver executable. To run web tests with Android 7.1.1 image which by default contains chrome v53, chromedriver version 2.26 has to be used. More recent chromedriver versions require chrome v54 and up.
 ```bash
 docker run --privileged -d -p 6080:6080 -p 5554:5554 -p 5555:5555 -p 4723:4723 -v /path/to/chromedriver:/root/chromedriver  -e CHROMEDRIVER_EXECUTABLE=/root/chromedriver/chromedriver -e DEVICE="Samsung Galaxy S6" -e APPIUM=True --name android-container butomo1989/docker-android-x86-7.1.1
 ```
@@ -210,3 +211,4 @@ docker exec -it android-container tail -f /var/log/supervisor/docker-android.std
 [1.13.0]: <https://github.com/docker/compose/releases/tag/1.13.0>
 [adb_connection]: <images/adb_connection.png>
 [sms]: <images/SMS.png>
+[chromedriver]: <https://chromedriver.storage.googleapis.com/index.html>

--- a/src/app.py
+++ b/src/app.py
@@ -102,6 +102,10 @@ def appium_run(avd_name: str):
     cmd = 'appium'
     local_ip = os.popen('ifconfig eth0 | grep \'inet addr:\' | cut -d: -f2 | awk \'{ print $1}\'').read().strip()
 
+    chromedriver_executable = os.getenv('CHROMEDRIVER_EXECUTABLE', False)
+    if chromedriver_executable:
+        cmd += ' --chromedriver-executable {executable}'.format(executable=chromedriver_executable)
+
     grid_connect = convert_str_to_bool(str(os.getenv('CONNECT_TO_GRID', False)))
     logger.info('Connect to selenium grid? {connect}'.format(connect=grid_connect))
     if grid_connect:

--- a/src/tests/unit/test_appium.py
+++ b/src/tests/unit/test_appium.py
@@ -12,7 +12,19 @@ class TestAppium(TestCase):
 
     def setUp(self):
         os.environ['CONNECT_TO_GRID'] = str(True)
+        os.environ['CHROMEDRIVER_EXECUTABLE'] = str(False)
         self.avd_name = 'test_avd'
+
+    @mock.patch('os.popen')
+    @mock.patch('subprocess.check_call')
+    def test_with_chromedriver_executable(self, mocked_os, mocked_subprocess):
+        os.environ['CONNECT_TO_GRID'] = str(False)
+        os.environ['CHROMEDRIVER_EXECUTABLE'] = '/root/chromedriver'
+        self.assertFalse(mocked_os.called)
+        self.assertFalse(mocked_subprocess.called)
+        app.appium_run(self.avd_name)
+        self.assertTrue(mocked_os.called)
+        self.assertTrue(mocked_subprocess.called)
 
     @mock.patch('os.popen')
     @mock.patch('subprocess.check_call')


### PR DESCRIPTION
Possibility to run appium with custom chromedriver executable in case the one bundled with appium server installation isn't compatible with chrome browser version under test.