### PR TITLE
Application name

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,16 @@ It is also possible to connect appium server that run inside docker-android with
 - SELENIUM_HOST="\<host\_ip\_address>"
 - SELENIUM_PORT=\<port\_number>
 
+To be able to get exact node from the grid by it's id, provide following environment variable:
+
+- APPLICATION_NAME="\<device\_unique\_id>"
+
 To run tests for mobile browser, following parameter can be passed:
 
 - MOBILE\_WEB\_TEST=True
 
 ```bash
-docker run --privileged -d -p 6080:6080 -p 4723:4723 -p 5554:5554 -p 5555:5555 -e DEVICE="Samsung Galaxy S6" -e APPIUM=True -e CONNECT_TO_GRID=True -e APPIUM_HOST="127.0.0.1" -e APPIUM_PORT=4723 -e SELENIUM_HOST="172.17.0.1" -e SELENIUM_PORT=4444 -e MOBILE_WEB_TEST=True --name android-container butomo1989/docker-android-x86-7.1.1
+docker run --privileged -d -p 6080:6080 -p 4723:4723 -p 5554:5554 -p 5555:5555 -e DEVICE="Samsung Galaxy S6" -e APPIUM=True -e CONNECT_TO_GRID=True -e APPIUM_HOST="127.0.0.1" -e APPIUM_PORT=4723 -e SELENIUM_HOST="172.17.0.1" -e SELENIUM_PORT=4444 -e MOBILE_WEB_TEST=True -e APPLICATION_NAME="samsung_s6_711" --name android-container butomo1989/docker-android-x86-7.1.1
 ```
 
 ### Share Volume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - APPIUM=true
       - SELENIUM_HOST=selenium_hub
       - AUTO_RECORD=True
+      - APPLICATION_NAME=nexus_711
 
   # Docker-Android for mobile website testing with chrome browser
   # Chrome browser exists only for version 7.0 and 7.1.1
@@ -47,6 +48,7 @@ services:
       - SELENIUM_HOST=selenium_hub
       - MOBILE_WEB_TEST=True
       - AUTO_RECORD=True
+      - APPLICATION_NAME=samsung_711
 
   # Docker-Android for mobile website testing with default browser
   # Default browser exists only for version 5.0.1, 5.1.1 and 6.0
@@ -66,3 +68,4 @@ services:
       - SELENIUM_HOST=selenium_hub
       - MOBILE_WEB_TEST=True
       - AUTO_RECORD=True
+      - APPLICATION_NAME=samsung_511

--- a/src/app.py
+++ b/src/app.py
@@ -133,7 +133,7 @@ def appium_run(avd_name: str):
 
 
 def create_node_config(avd_name: str, browser_name: str, appium_host: str, appium_port: int, selenium_host: str,
-                       selenium_port: int, application_name: str):
+                       selenium_port: int, application_name: str=''):
     """
     Create custom node config file in json format to be able to connect with selenium server.
 

--- a/src/app.py
+++ b/src/app.py
@@ -86,9 +86,9 @@ def prepare_avd(device: str, avd_name: str):
 
     avd_path = '/'.join([ANDROID_HOME, 'android_emulator'])
     creation_cmd = 'avdmanager create avd -f -n {name} -b {img_type}/{sys_img} -k "system-images;android-{api_lvl};' \
-        '{img_type};{sys_img}" -d {device} -p {path}'.format(name=avd_name, img_type=IMG_TYPE, sys_img=SYS_IMG,
-                                                             api_lvl=API_LEVEL, device=device_name_bash,
-                                                             path=avd_path)
+                   '{img_type};{sys_img}" -d {device} -p {path}'.format(name=avd_name, img_type=IMG_TYPE,
+                                                                        sys_img=SYS_IMG, api_lvl=API_LEVEL,
+                                                                        device=device_name_bash, path=avd_path)
     logger.info('Command to create avd: {command}'.format(command=creation_cmd))
     subprocess.check_call(creation_cmd, shell=True)
 
@@ -122,7 +122,9 @@ def appium_run(avd_name: str):
             selenium_host = os.getenv('SELENIUM_HOST', '172.17.0.1')
             selenium_port = int(os.getenv('SELENIUM_PORT', 4444))
             browser_name = default_web_browser if mobile_web_test else 'android'
-            create_node_config(avd_name, browser_name, appium_host, appium_port, selenium_host, selenium_port)
+            application_name = os.getenv('APPLICATION_NAME', '')
+            create_node_config(avd_name, browser_name, appium_host, appium_port, selenium_host, selenium_port,
+                               application_name)
             cmd += ' --nodeconfig {file}'.format(file=CONFIG_FILE)
         except ValueError as v_err:
             logger.error(v_err)
@@ -131,15 +133,17 @@ def appium_run(avd_name: str):
 
 
 def create_node_config(avd_name: str, browser_name: str, appium_host: str, appium_port: int, selenium_host: str,
-                       selenium_port: int):
+                       selenium_port: int, application_name: str):
     """
     Create custom node config file in json format to be able to connect with selenium server.
 
+    :param browser_name: Browser name. def: android
     :param avd_name: Name of android virtual device / emulator
     :param appium_host: Host where appium server is running
     :param appium_port: Port number where where appium server is running
     :param selenium_host: Host where selenium server is running
     :param selenium_port: Port number where selenium server is running
+    :param application_name: Name, to determine exact node
     """
     config = {
         'capabilities': [
@@ -150,6 +154,7 @@ def create_node_config(avd_name: str, browser_name: str, appium_host: str, appiu
                 'browserName': browser_name,
                 'deviceName': avd_name,
                 'maxInstances': 1,
+                'applicationName': application_name,
             }
         ],
         'configuration': {
@@ -191,6 +196,7 @@ def run():
     if appium:
         logger.info('Run appium server...')
         appium_run(avd_name)
+
 
 if __name__ == '__main__':
     run()

--- a/src/tests/unit/test_appium.py
+++ b/src/tests/unit/test_appium.py
@@ -3,6 +3,7 @@ import os
 from unittest import TestCase
 
 import mock
+import uuid
 
 from src import app
 
@@ -60,6 +61,15 @@ class TestAppium(TestCase):
         self.assertFalse(os.path.exists(CONFIG_FILE))
         app.create_node_config('test', 'android', '127.0.0.1', 4723, '127.0.0.1', 4444)
         self.assertTrue(os.path.exists(CONFIG_FILE))
+        os.remove(CONFIG_FILE)
+
+    def test_config_contains_device_id(self):
+        from src import CONFIG_FILE
+        self.assertFalse(os.path.exists(CONFIG_FILE))
+        device_id = 'UniqueDeviceId_{random_id}'.format(random_id=uuid.uuid4())
+        app.create_node_config('test', 'android', '127.0.0.1', 4723, '127.0.0.1', 4444, '%s' % device_id)
+        self.assertTrue(os.path.exists(CONFIG_FILE))
+        self.assertTrue(device_id in open(os.path.exists(CONFIG_FILE)).read())
         os.remove(CONFIG_FILE)
 
     def tearDown(self):


### PR DESCRIPTION
Added application name capability to be able to get exact node from Selenium Grid.

According to Selenium implementation, selenium doesn't use application name. On other hand,
 user can use this parameter in capabilities to identify node and then request it from Grid,
by adding it to desiredCapability