### PR TITLE
force update to last sdk

### DIFF
--- a/docker/Emulator_arm
+++ b/docker/Emulator_arm
@@ -85,7 +85,8 @@ ENV ANDROID_VERSION=$ANDROID_VERSION \
 ENV PATH ${PATH}:${ANDROID_HOME}/build-tools
 RUN echo y | sdkmanager "platforms;android-${API_LEVEL}" && \
     echo y | sdkmanager "system-images;android-${API_LEVEL};${IMG_TYPE};${SYS_IMG}" && \
-    echo y | sdkmanager "emulator"
+    echo y | sdkmanager "emulator" && \
+    echo y | sdkmanager --update
 RUN rm ${ANDROID_HOME}/tools/emulator \
  && ln -s ${ANDROID_HOME}/emulator/emulator64-${PROCESSOR} ${ANDROID_HOME}/tools/emulator
 ENV LD_LIBRARY_PATH=$ANDROID_HOME/emulator/lib64:$ANDROID_HOME/emulator/lib64/qt/lib

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -98,7 +98,8 @@ ENV ANDROID_VERSION=$ANDROID_VERSION \
 ENV PATH ${PATH}:${ANDROID_HOME}/build-tools
 RUN echo y | sdkmanager "platforms;android-${API_LEVEL}" && \
     echo y | sdkmanager "system-images;android-${API_LEVEL};${IMG_TYPE};${SYS_IMG}" && \
-    echo y | sdkmanager "emulator"
+    echo y | sdkmanager "emulator" \
+    echo y | sdkmanager --update
 RUN rm ${ANDROID_HOME}/tools/emulator \
  && ln -s ${ANDROID_HOME}/emulator/emulator64-${PROCESSOR} ${ANDROID_HOME}/tools/emulator
 ENV LD_LIBRARY_PATH=$ANDROID_HOME/emulator/lib64:$ANDROID_HOME/emulator/lib64/qt/lib

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -98,7 +98,7 @@ ENV ANDROID_VERSION=$ANDROID_VERSION \
 ENV PATH ${PATH}:${ANDROID_HOME}/build-tools
 RUN echo y | sdkmanager "platforms;android-${API_LEVEL}" && \
     echo y | sdkmanager "system-images;android-${API_LEVEL};${IMG_TYPE};${SYS_IMG}" && \
-    echo y | sdkmanager "emulator" \
+    echo y | sdkmanager "emulator" && \
     echo y | sdkmanager --update
 RUN rm ${ANDROID_HOME}/tools/emulator \
  && ln -s ${ANDROID_HOME}/emulator/emulator64-${PROCESSOR} ${ANDROID_HOME}/tools/emulator


### PR DESCRIPTION
### Purpose of changes
Force update to last SDK to get the last emulator version. To try resolve some failed to run. #69 
Maybe we shoud update [https://github.com/appium/appium-docker-android/blob/master/Appium/Dockerfile](https://github.com/appium/appium-docker-android/blob/master/Appium/Dockerfile) line 86 to "ARG APPIUM_VERSION=1.7.2"
[https://github.com/appium/appium/blob/master/CHANGELOG.md](https://github.com/appium/appium/blob/master/CHANGELOG.md) => "Add support for MacOS 10.13"

### Types of changes
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
