### PR TITLE
Use latest version of chromedriver

### DIFF
--- a/docker/Emulator_arm
+++ b/docker/Emulator_arm
@@ -91,11 +91,11 @@ RUN rm ${ANDROID_HOME}/tools/emulator \
 ENV LD_LIBRARY_PATH=$ANDROID_HOME/emulator/lib64:$ANDROID_HOME/emulator/lib64/qt/lib
 
 #==============================================
-#       Download chrome driver
-# to be able to use chrome browser in emulator
-# Issue: https://github.com/butomo1989/docker-android/commit/6406504f944dae73d0a0c5d8e71a17a47dff9b33
+# Download latest version of chromedriver
+# to be able to use Chrome browser in emulator
 #==============================================
-RUN wget -nv -O chrome.zip "https://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip" \
+RUN LATEST_VERSION=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+ && wget -nv -O chrome.zip "https://chromedriver.storage.googleapis.com/$LATEST_VERSION/chromedriver_linux64.zip" \
  && unzip -x chrome.zip \
  && rm chrome.zip
 

--- a/docker/Emulator_arm
+++ b/docker/Emulator_arm
@@ -91,11 +91,11 @@ RUN rm ${ANDROID_HOME}/tools/emulator \
 ENV LD_LIBRARY_PATH=$ANDROID_HOME/emulator/lib64:$ANDROID_HOME/emulator/lib64/qt/lib
 
 #==============================================
-#       Download chrome driver v2.26
+#       Download chrome driver
 # to be able to use chrome browser in emulator
 # Issue: https://github.com/butomo1989/docker-android/commit/6406504f944dae73d0a0c5d8e71a17a47dff9b33
 #==============================================
-RUN wget -nv -O chrome.zip "https://chromedriver.storage.googleapis.com/2.26/chromedriver_linux64.zip" \
+RUN wget -nv -O chrome.zip "https://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip" \
  && unzip -x chrome.zip \
  && rm chrome.zip
 

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -105,11 +105,11 @@ ENV LD_LIBRARY_PATH=$ANDROID_HOME/emulator/lib64:$ANDROID_HOME/emulator/lib64/qt
 
 
 #==============================================
-#       Download chrome driver
-# to be able to use chrome browser in emulator
-# Issue: https://github.com/butomo1989/docker-android/commit/6406504f944dae73d0a0c5d8e71a17a47dff9b33
+# Download latest version of chromedriver
+# to be able to use Chrome browser in emulator
 #==============================================
-RUN wget -nv -O chrome.zip "https://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip" \
+RUN LATEST_VERSION=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+ && wget -nv -O chrome.zip "https://chromedriver.storage.googleapis.com/$LATEST_VERSION/chromedriver_linux64.zip" \
  && unzip -x chrome.zip \
  && rm chrome.zip
 

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -105,11 +105,11 @@ ENV LD_LIBRARY_PATH=$ANDROID_HOME/emulator/lib64:$ANDROID_HOME/emulator/lib64/qt
 
 
 #==============================================
-#       Download chrome driver v2.26
+#       Download chrome driver
 # to be able to use chrome browser in emulator
 # Issue: https://github.com/butomo1989/docker-android/commit/6406504f944dae73d0a0c5d8e71a17a47dff9b33
 #==============================================
-RUN wget -nv -O chrome.zip "https://chromedriver.storage.googleapis.com/2.26/chromedriver_linux64.zip" \
+RUN wget -nv -O chrome.zip "https://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip" \
  && unzip -x chrome.zip \
  && rm chrome.zip
 


### PR DESCRIPTION
### Purpose of changes
Update the version of [chromedriver](http://chromedriver.chromium.org/downloads) in order to use latest version of Chrome in the Android device through an Appium client.

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
When using Chrome as browser in the latest version of Docker images through an Appium client, I get the following error:

`An unknown server-side error occurred while processing the command. (Original error: unknown error: Chrome version must be >= 53.0.2785.0)`

This is due to an incompatibility between Chrome and chromedriver. This should be fixed by upgrading the version of chromedriver.
