### PR TITLE
Fix adb getting into the loop

### DIFF
--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -151,6 +151,6 @@ COPY supervisord.conf /root/
 RUN chmod -R +x /root/src && chmod +x /root/supervisord.conf
 
 HEALTHCHECK --interval=2s --timeout=40s --retries=1 \
-    CMD adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done'
+    CMD timeout 40 adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done'
 
 CMD /usr/bin/supervisord --configuration supervisord.conf


### PR DESCRIPTION
### Purpose of changes
Fix adb getting into the loop after container become unhealthy

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Tried to run this adb command with broken emulator. The command have exited

Fixes #86 