### PR TITLE
Download proper version of chromedriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,17 @@ Advantages compare with other docker-android projects
 List of Docker images
 ---------------------
 
-|Supported OS   |Android version   |API level   |Image name   |Image status   |
-|:---|:---|:---|:---|:---:|
-|Linux|5.0.1|21|butomo1989/docker-android-x86-5.0.1|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-5.0.1.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-5.0.1 "Get your own image badge on microbadger.com")|
-|Linux|5.1.1|22|butomo1989/docker-android-x86-5.1.1|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-5.1.1.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-5.1.1 "Get your own image badge on microbadger.com")|
-|Linux|6.0|23|butomo1989/docker-android-x86-6.0|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-6.0.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-6.0 "Get your own image badge on microbadger.com")|
-|Linux|7.0|24|butomo1989/docker-android-x86-7.0|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-7.0.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-7.0 "Get your own image badge on microbadger.com")|
-|Linux|7.1.1|25|butomo1989/docker-android-x86-7.1.1|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-7.1.1.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-7.1.1 "Get your own image badge on microbadger.com")|
-|Linux|8.0|26|butomo1989/docker-android-x86-8.0|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-8.0.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-8.0 "Get your own image badge on microbadger.com")|
-|Linux|8.1|27|butomo1989/docker-android-x86-8.1|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-8.1.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-8.1 "Get your own image badge on microbadger.com")|
-|All |-|-|butomo1989/docker-android-real-device|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-real-device.svg)](https://microbadger.com/images/butomo1989/docker-android-real-device "Get your own image badge on microbadger.com")|
-|Linux|All|All|butomo1989/docker-android-genymotion|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-genymotion.svg)](https://microbadger.com/images/butomo1989/docker-android-genymotion "Get your own image badge on microbadger.com")|
+|Supported OS   |Android version   |API level   |Browser name   |Browser version   |chromedriver version   |Image name   |Image status   |
+|:---|:---|:---|:---|:---:|:---|:---|:---|
+|Linux|5.0.1|21|browser|37.0|2.12|butomo1989/docker-android-x86-5.0.1|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-5.0.1.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-5.0.1 "Get your own image badge on microbadger.com")|
+|Linux|5.1.1|22|browser|39.0|2.13|butomo1989/docker-android-x86-5.1.1|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-5.1.1.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-5.1.1 "Get your own image badge on microbadger.com")|
+|Linux|6.0|23|browser|44.0|2.18|butomo1989/docker-android-x86-6.0|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-6.0.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-6.0 "Get your own image badge on microbadger.com")|
+|Linux|7.0|24|chrome|51.0|2.23|butomo1989/docker-android-x86-7.0|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-7.0.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-7.0 "Get your own image badge on microbadger.com")|
+|Linux|7.1.1|25|chrome|55.0|2.28|butomo1989/docker-android-x86-7.1.1|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-7.1.1.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-7.1.1 "Get your own image badge on microbadger.com")|
+|Linux|8.0|26|chrome|58.0|2.31|butomo1989/docker-android-x86-8.0|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-8.0.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-8.0 "Get your own image badge on microbadger.com")|
+|Linux|8.1|27|chrome|61.0|2.33|butomo1989/docker-android-x86-8.1|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-8.1.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-8.1 "Get your own image badge on microbadger.com")|
+|All |-|-|-|-|-|butomo1989/docker-android-real-device|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-real-device.svg)](https://microbadger.com/images/butomo1989/docker-android-real-device "Get your own image badge on microbadger.com")|
+|Linux|All|All|-|-|-|butomo1989/docker-android-genymotion|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-genymotion.svg)](https://microbadger.com/images/butomo1989/docker-android-genymotion "Get your own image badge on microbadger.com")|
 
 List of Devices
 ---------------

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -89,20 +89,19 @@ ARG PROCESSOR=x86
 ARG SYS_IMG=x86
 ARG IMG_TYPE=google_apis
 ARG BROWSER=android
-ARG CHROME_DRIVER=24
 ENV ANDROID_VERSION=$ANDROID_VERSION \
     API_LEVEL=$API_LEVEL \
     PROCESSOR=$PROCESSOR \
     SYS_IMG=$SYS_IMG \
     IMG_TYPE=$IMG_TYPE \
     BROWSER=$BROWSER \
-    CHROME_DRIVER=2.40
+    CHROME_DRIVER=$CHROME_DRIVER
 ENV PATH ${PATH}:${ANDROID_HOME}/build-tools
 RUN yes | sdkmanager --licenses && \
     sdkmanager "platforms;android-${API_LEVEL}" "system-images;android-${API_LEVEL};${IMG_TYPE};${SYS_IMG}" "emulator"
 
 #==============================================
-# Download latest version of chromedriver
+# Download proper version of chromedriver
 # to be able to use Chrome browser in emulator
 #==============================================
 RUN wget -nv -O chrome.zip "https://chromedriver.storage.googleapis.com/${CHROME_DRIVER}/chromedriver_linux64.zip" \

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -89,6 +89,7 @@ ARG PROCESSOR=x86
 ARG SYS_IMG=x86
 ARG IMG_TYPE=google_apis
 ARG BROWSER=android
+ARG CHROME_DRIVER=2.40
 ENV ANDROID_VERSION=$ANDROID_VERSION \
     API_LEVEL=$API_LEVEL \
     PROCESSOR=$PROCESSOR \
@@ -97,6 +98,7 @@ ENV ANDROID_VERSION=$ANDROID_VERSION \
     BROWSER=$BROWSER \
     CHROME_DRIVER=$CHROME_DRIVER
 ENV PATH ${PATH}:${ANDROID_HOME}/build-tools
+
 RUN yes | sdkmanager --licenses && \
     sdkmanager "platforms;android-${API_LEVEL}" "system-images;android-${API_LEVEL};${IMG_TYPE};${SYS_IMG}" "emulator"
 

--- a/release.sh
+++ b/release.sh
@@ -31,6 +31,18 @@ declare -A list_of_levels=(
         [8.1]=27
 )
 
+# The version of the Chrome browser installed on the Android emulator needs to be known beforehand
+# in order to chose the proper version of chromedriver (see http://chromedriver.chromium.org/downloads)
+declare -A chromedriver_versions=(
+        [5.0.1]="2.12"
+        [5.1.1]="2.13"
+        [6.0]="2.18"
+        [7.0]="2.23"
+        [7.1.1]="2.28"
+        [8.0]="2.31"
+        [8.1]="2.33"
+)
+
 function get_android_versions() {
     versions=()
 
@@ -57,9 +69,6 @@ function get_android_versions() {
 
 get_android_versions
 processor=x86
-#chrome_driver=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
-#Reason: https://sites.google.com/a/chromium.org/chromedriver/downloads
-chrome_driver=2.33
 
 function test() {
     # Prepare needed parameter to run tests
@@ -143,6 +152,8 @@ function build() {
         echo "[BUILD] API Level: $level"
         sys_img=$processor
         echo "[BUILD] System Image: $sys_img"
+        chrome_driver="${chromedriver_versions[$v]}"
+        echo "[BUILD] chromedriver version: $chrome_driver"
         image_version="$IMAGE-$processor-$v:$RELEASE"
         image_latest="$IMAGE-$processor-$v:latest"
         echo "[BUILD] Image name: $image_version and $image_latest"

--- a/src/app.py
+++ b/src/app.py
@@ -125,8 +125,7 @@ def appium_run(avd_name: str):
         cmd += ' --relaxed-security'
 
     default_web_browser = os.getenv('BROWSER')
-    if default_web_browser == 'chrome':
-        cmd += ' --chromedriver-executable {driver}'.format(driver=CHROME_DRIVER)
+    cmd += ' --chromedriver-executable {driver}'.format(driver=CHROME_DRIVER)
 
     grid_connect = convert_str_to_bool(str(os.getenv('CONNECT_TO_GRID', False)))
     logger.info('Connect to selenium grid? {connect}'.format(connect=grid_connect))


### PR DESCRIPTION
### Purpose of changes
The version of *chromedriver* (see [here](http://chromedriver.chromium.org/downloads)) is related to the version of the Chrome browser which is managed by tests (Appium clients). Currently, the version of *chromedriver* installed in the Docker containers is fixed (2.40). On the other hand, the version of the browsers change, and as a result, browsers cannot be used from Appium tests.

I've made some research and I have found the version of the browsers installed in the different Docker containers. The following table summarizes the findings:

|Android version|Browser name|Browser version|Required chromedriver|
|-|-|-|-|
|5.0.1|browser|37.0.0|2.12|
|5.1.1|browser|39.0.0|2.13|
|6.0|browser|44.0.2403|2.18|
|7.0|chrome|51.0.2704.90|2.23|
|7.1.1|chrome|55.0.2883.91|2.28|
|8.0|chrome|58.0.3029.125|2.31|
|8.1|chrome|61.0.3163.98|2.33|

This PR selects the proper version of *chromedriver* to be stored in the Docker container, which is later required by the Appium Server.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?

I have started manually the latest version of docker containers, using a Appium client to connect to the Appium Server (see test [here](https://github.com/bonigarcia/selenium-jupiter/blob/master/src/test/java/io/github/bonigarcia/test/advance/AppiumWithGlobalOptionsChromeJupiterTest.java)). Then, I have changed manually the version of *chromedriver*, checking that the test actually passes.

**Note 1**: I've checked that *chromedriver* is also required for default Android *browser* (`com.android.browser`), available on 5.0.1, 5.1, and 6.0. For that reason the param `--chromedriver-executable` needs to be honored always in `app.py`. Otherwise, the *chromedriver* to be used in these containers will be 2.38.552522 (located in `/usr/lib/node_modules/appium/node_modules/appium-chromedriver/chromedriver/linux/chromedriver_64`, which is also incorrect).

**Note 2**: Tests using Android 5.0.1 are not working. Maybe (I'm not sure) is due to some problem with adb (I've seen that adb process in defunct in this container, and this is not happening in the rest of containers).
