### PR TITLE
Added device_id support via ENV variable or auto uuid values

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -192,8 +192,11 @@ def create_node_config(avd_name: str, browser_name: str, appium_host: str, appiu
 def run():
     """Run app."""
     device = os.getenv('DEVICE', 'Nexus 5')
-    device_id = os.getenv('DEVICE_ID', str(uuid.uuid4()))
     logger.info('Device: {device}'.format(device=device))
+    
+    device_id = os.getenv('DEVICE_ID', str(uuid.uuid4()))
+    logger.info('Device Id: {device_id}'.format(device_id=device_id))
+
 
     avd_name = '{device}_{version}'.format(device=device.replace(' ', '_').lower(), version=ANDROID_VERSION)
     logger.info('AVD name: {avd}'.format(avd=avd_name))

--- a/src/app.py
+++ b/src/app.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import subprocess
+import uuid
 
 from src import CHROME_DRIVER, CONFIG_FILE, ROOT
 from src import log
@@ -191,6 +192,7 @@ def create_node_config(avd_name: str, browser_name: str, appium_host: str, appiu
 def run():
     """Run app."""
     device = os.getenv('DEVICE', 'Nexus 5')
+    device_id = os.getenv('DEVICE_ID', str(uuid.uuid4()))
     logger.info('Device: {device}'.format(device=device))
 
     avd_name = '{device}_{version}'.format(device=device.replace(' ', '_').lower(), version=ANDROID_VERSION)
@@ -208,9 +210,9 @@ def run():
         cfg.write('\ndisk.dataPartition.size={dp}'.format(dp=dp_size))
 
     if is_first_run:
-        cmd = 'emulator/emulator @{name} -gpu off -verbose -wipe-data'.format(name=avd_name)
+        cmd = 'emulator/emulator @{name} -gpu off -prop emu.uuid={uuid} -verbose -wipe-data'.format(name=avd_name, uuid=device_id)
     else:
-        cmd = 'emulator/emulator @{name} -gpu off -verbose'.format(name=avd_name)
+        cmd = 'emulator/emulator @{name} -gpu off -prop emu.uuid={uuid} -verbose'.format(name=avd_name, uuid=device_id)
     appium = convert_str_to_bool(str(os.getenv('APPIUM', False)))
     if appium:
         subprocess.Popen(cmd.split())

--- a/src/app.py
+++ b/src/app.py
@@ -193,10 +193,8 @@ def run():
     """Run app."""
     device = os.getenv('DEVICE', 'Nexus 5')
     logger.info('Device: {device}'.format(device=device))
-    
     device_id = os.getenv('DEVICE_ID', str(uuid.uuid4()))
     logger.info('Device Id: {device_id}'.format(device_id=device_id))
-
 
     avd_name = '{device}_{version}'.format(device=device.replace(' ', '_').lower(), version=ANDROID_VERSION)
     logger.info('AVD name: {avd}'.format(avd=avd_name))


### PR DESCRIPTION
### Purpose of changes
Currently not able to set custom device id for emulator

### Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
While launching the docker image, passing the device_id value via environmrnt variable will launch the emulator with that mentioned device_id or an auto generate UUID will be set instead.