### PR TITLE
AVD initialisation based on devices xml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ To run tests for mobile browser, following parameter can be passed:
 docker run --privileged -d -p 6080:6080 -p 4723:4723 -p 5554:5554 -p 5555:5555 -e DEVICE="Samsung Galaxy S6" -e APPIUM=true -e CONNECT_TO_GRID=true -e APPIUM_HOST="127.0.0.1" -e APPIUM_PORT=4723 -e SELENIUM_HOST="172.17.0.1" -e SELENIUM_PORT=4444 -e MOBILE_WEB_TEST=true --name android-container butomo1989/docker-android-x86-8.1
 ```
 
+### Back & Restore
+If you want to backup/reuse the avds created with furture upgrades or for replication, run the container with two extra mounts
+
+- -v local_backup/.android:/root/.android
+- -v local_backup/android_emulator:/root/android_emulator
+
+```bash
+docker run --privileged -d -p 6080:6080 -p 4723:4723 -p 5554:5554 -p 5555:5555 -v local_backup/.android:/root/.android -v local_backup/android_emulator:local_backup/android_emulator -e DEVICE="Nexus 5" -e APPIUM=true -e CONNECT_TO_GRID=true -e APPIUM_HOST="127.0.0.1" -e APPIUM_PORT=4723 -e SELENIUM_HOST="172.17.0.1" -e SELENIUM_PORT=4444 --name android-container butomo1989/docker-android-x86-8.1
+```
+For the first run, this will create a new avd and all the changes will be accessible in the `local_backup` directory. 
+
+Now for all future runs, it will reuse the avds. Even this should work with new releases of `docker-android`
+
+
 ### Share Volume
 
 If you want to use appium to test UI of your android application, you need to share volume where the APK is located to folder ***/root/tmp***.

--- a/src/app.py
+++ b/src/app.py
@@ -51,13 +51,7 @@ def convert_str_to_bool(str: str) -> bool:
 
 
 def is_initialized() -> bool:
-    return os.path.exists(INIT_FILE)
-
-
-def finish_initialization():
-    file = open(INIT_FILE, 'w+')
-    file.close()
-
+    return os.path.exists(os.path.join(ROOT, '.android', 'devices.xml'))
 
 ANDROID_HOME = get_or_raise('ANDROID_HOME')
 ANDROID_VERSION = get_or_raise('ANDROID_VERSION')
@@ -65,7 +59,6 @@ API_LEVEL = get_or_raise('API_LEVEL')
 PROCESSOR = get_or_raise('PROCESSOR')
 SYS_IMG = get_or_raise('SYS_IMG')
 IMG_TYPE = get_or_raise('IMG_TYPE')
-INIT_FILE = os.getenv('INIT_FILE', "/root/init")
 
 logger.info('Android version: {version} \n'
             'API level: {level} \n'
@@ -203,7 +196,6 @@ def run():
     if is_first_run:
         logger.info('Preparing emulator...')
         prepare_avd(device, avd_name)
-        finish_initialization()
 
     logger.info('Run emulator...')
     dp_size = os.getenv('DATAPARTITION', '550m')


### PR DESCRIPTION
### Purpose of changes
<!-- Please describe why this change is required / What problem you want to solve. -->
On boot, it should check if there are existing emulators or not, rather than random init flag. The usecase is when I am mounting previously created avds, its still recreates a new one, because its looking for init file.

### Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Lunching x86 docker with extra mounted volumes
  -v external_path/.android:/root/.android
  -v external_path/android_emulator:/root/android_emulator

will not create a new AVD, will use the existing mounted ones.

