### PR TITLE
Fix chromedriver version for Android 5.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ List of Docker images
 
 |OS   |Android   |API   |Browser   |Browser version   |Chromedriver   |Image   |Size   |
 |:---|:---|:---|:---|:---|:---|:---|:---|
-|Linux|5.0.1|21|browser|37.0|2.12|butomo1989/docker-android-x86-5.0.1|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-5.0.1.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-5.0.1 "Get your own image badge on microbadger.com")|
+|Linux|5.0.1|21|browser|37.0|2.21|butomo1989/docker-android-x86-5.0.1|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-5.0.1.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-5.0.1 "Get your own image badge on microbadger.com")|
 |Linux|5.1.1|22|browser|39.0|2.13|butomo1989/docker-android-x86-5.1.1|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-5.1.1.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-5.1.1 "Get your own image badge on microbadger.com")|
 |Linux|6.0|23|browser|44.0|2.18|butomo1989/docker-android-x86-6.0|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-6.0.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-6.0 "Get your own image badge on microbadger.com")|
 |Linux|7.0|24|chrome|51.0|2.23|butomo1989/docker-android-x86-7.0|[![](https://images.microbadger.com/badges/image/butomo1989/docker-android-x86-7.0.svg)](https://microbadger.com/images/butomo1989/docker-android-x86-7.0 "Get your own image badge on microbadger.com")|

--- a/release.sh
+++ b/release.sh
@@ -34,7 +34,7 @@ declare -A list_of_levels=(
 # The version of the Chrome browser installed on the Android emulator needs to be known beforehand
 # in order to chose the proper version of chromedriver (see http://chromedriver.chromium.org/downloads)
 declare -A chromedriver_versions=(
-        [5.0.1]="2.12"
+        [5.0.1]="2.21"
         [5.1.1]="2.13"
         [6.0]="2.18"
         [7.0]="2.23"


### PR DESCRIPTION
### Purpose of changes
The version of chromedriver for Android 5.0.1 was wrong. As reported in PR #100 (note 2), tests was not working properly in this version. I have discovered that for Android _browser_ (`com.android.browser` package) using Chrome webview 37.0.0, the proper version of chromedriver is 2.21 (see this [page](https://discuss.appium.io/t/can-t-find-elements-on-a-webview-page-of-an-android-native-app-using-appium-and-python/10104/8)).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
I have started manually the version 5.0.1 of docker-android containers, using a Appium client to connect to the Appium Server by means of a Selenium [test](https://github.com/bonigarcia/selenium-jupiter/blob/master/src/test/java/io/github/bonigarcia/test/advance/AppiumWithGlobalOptionsChromeJupiterTest.java).

