### PR TITLE
Add AWS Instruction

### DIFF
--- a/README_CLOUD.md
+++ b/README_CLOUD.md
@@ -3,3 +3,8 @@ Azure
 
 Make sure that the nodes, pods, containers for your emulators are generated within a **VM** of series **Dv3** or **Ev3**.
 Reference: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nested-virtualization
+
+AWS
+-----
+Make sure that containers for your emulators are generated within a EC2 Bare Metal Instance(i3.metal)
+Reference: https://aws.amazon.com/jp/blogs/aws/new-amazon-ec2-bare-metal-instances-with-direct-access-to-hardware/


### PR DESCRIPTION
Instruction to use EC2 Bare Metal Instance

### Purpose of changes
In order to know users to use EC2 Bare Metal Instance if they want to use in AWS

### Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
