### PR TITLE
Add Cloud instructions for GCE

### DIFF
--- a/README_CLOUD.md
+++ b/README_CLOUD.md
@@ -8,3 +8,8 @@ AWS
 -----
 Make sure that containers for your emulators are generated within a EC2 Bare Metal Instance(i3.metal)
 Reference: https://aws.amazon.com/jp/blogs/aws/new-amazon-ec2-bare-metal-instances-with-direct-access-to-hardware/
+
+Google Cloud (GCE)
+------------------
+Make sure your instances for your emulators have Nested Virtualization enabled
+Reference: https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances#enablenestedvirt

--- a/README_CLOUD.md
+++ b/README_CLOUD.md
@@ -12,4 +12,14 @@ Reference: https://aws.amazon.com/jp/blogs/aws/new-amazon-ec2-bare-metal-instanc
 Google Cloud (GCE)
 ------------------
 Make sure your instances for your emulators have Nested Virtualization enabled
-Reference: https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances#enablenestedvirt
+Reference: https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances
+
+One the disk and instance are created as [specified here](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances#enablenestedvirt),
+the emulator can be brought up as follows:
+
+    # Assume app.apk is in /tmp
+    docker run --privileged -d -e DEVICE="Samsung Galaxy S6" --volume /tmp:/APK \
+         --name android_em butomo1989/docker-android-x86-8.1
+
+    docker exec android_em adb wait-for-device 
+    docker exec android_em adb install /APK/app.apk


### PR DESCRIPTION
### Purpose of changes
I got the container to run on GCE and want to share how.

### How has this been tested?
Created a GCE instance following the linked instructions and ran the container there.